### PR TITLE
feat: initialize OpenVuln MCP server with API client and gitignore setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+.venv
+__pycache__
+*.pyc
+.env
+*.log
+*.pyo
+*.pyd
+*.pyw
+*.pyc
+
+# MacOS
+.DS_Store
+
+# IDE
+.idea
+.vscode
+
+# Windows
+Thumbs.db
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+httpx==0.27.0
+pyjson5==1.6.6
+fastmcp

--- a/src/openvuln_mcp_server.py
+++ b/src/openvuln_mcp_server.py
@@ -1,0 +1,21 @@
+import httpx
+import pyjson5
+from fastmcp import FastMCP
+
+# Creating an HTTP client for the Cisco OpenVuln API
+client = httpx.AsyncClient(base_url="https://apix.cisco.com/security/advisories/v2/")
+
+# Load the OpenAPI spec for the Cisco OpenVuln API
+openapi_spec = pyjson5.loads(httpx.get("https://pubhub.devnetcloud.com/media/psirt/docs/reference/api-v3.json").text)
+
+
+
+# Create the MCP server for the Cisco OpenVuln API
+mcp = FastMCP.from_openapi(
+    openapi_spec=openapi_spec,
+    client=client,
+    name="OpenVuln MCP Server"
+)
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
This pull request introduces a new `FastMCP` server implementation for the Cisco OpenVuln API in the `src/openvuln_mcp_server.py` file. It sets up an asynchronous HTTP client, loads the OpenAPI specification, and initializes the server.

Key changes:

* **HTTP Client Setup**:
  - Added an asynchronous HTTP client using `httpx` with the base URL for the Cisco OpenVuln API.

* **OpenAPI Specification Loading**:
  - Loaded the OpenAPI specification for the Cisco OpenVuln API using `pyjson5` and the `httpx` library.

* **FastMCP Server Initialization**:
  - Created and configured a `FastMCP` server using the loaded OpenAPI spec and the HTTP client, naming it "OpenVuln MCP Server".

* **Server Execution**:
  - Added a `__main__` block to run the MCP server.